### PR TITLE
Don't close the app if it was not created by us

### DIFF
--- a/TreeAIBox.py
+++ b/TreeAIBox.py
@@ -1589,18 +1589,10 @@ class TreeAIBoxWeb(QMainWindow):
                     worker.terminate()
                     worker.wait(3000)  # Wait up to 3 seconds
             self.web_interface.workers.clear()
-        
-        # Clear the global reference
-        app = QApplication.instance()
-        if app is not None:
-        #     print("Forcing application exit...")
-            app.quit()
-            QApplication.exit()
 
         # Accept the close event
-        #event.accept()
-        #super().closeEvent(event)
-
+        # event.accept()
+        # super().closeEvent(event)
 
     def loadHtmlContent(self):
         """Load the HTML UI"""
@@ -1632,14 +1624,14 @@ class TreeAIBoxWeb(QMainWindow):
             self.web_view.setHtml(html_content)
 
 
-
 if __name__ == "__main__":
     # Get existing QApplication instance or create new one if none exists
     app = QApplication.instance()
     if app is None:
         app = QApplication(sys.argv)
-        
-    window = TreeAIBoxWeb()
-    window.show()
-    sys.exit(app.exec())
-
+        window = TreeAIBoxWeb()
+        window.show()
+        sys.exit(app.exec())
+    else:
+        window = TreeAIBoxWeb()
+        window.show()


### PR DESCRIPTION
Don't close the app when its running within cloudcompare otherwise it kills CC

This will allow to run the script multiple times during a cloudcompare session


Also, technically, the way the script is organized is not truly a [plugin](https://tmontaigu.github.io/CloudCompare-PythonRuntime/getting_started.html#plugin), but is simply a script that is ran

A script would look like this
```
import pycc

from typing import List
from pathlib import Path
from PyQt5.QtWidgets import QWidget

class Window(pycc.PythonPluginInterface):
    def __init__(self):
        pycc.PythonPluginInterface.__init__(self)
        self.count = 0
        self.app = pycc.GetInstance()
        
        self.win = QTreeAIBoxWeb()
        self.win.setWindowTitle("PyQT win")

    def getActions(self) -> List[pycc.Action]:
        return [
            pycc.Action(name="Show Windows", target=self.showWindow),
        ]

    def showWindow(self):
        self.win.show()
```

